### PR TITLE
Update fastify

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
   "homepage": "https://github.com/nearform/node-clinic-flame-demoe#readme",
   "dependencies": {
     "express": "^4.16.3",
-    "fastify": "^1.8.0"
+    "fastify": "^2.14.1"
   }
 }


### PR DESCRIPTION
### Notes
master gives the following deprecation warning on `npm install`:
```console
$ npm install
npm WARN deprecated bourne@1.1.2: This module has moved and is now available at @hapi/bourne. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.
added 110 packages from 117 contributors and audited 110 packages in 2.614s

1 package is looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

This happens because of dependency in fastify@v1
```console
$ npm list bourne
node-clinic-flame-demo@1.0.0 /home/trivikr/workspace/node-clinic-flame-demo
└─┬ fastify@1.14.6
  └── bourne@1.1.2
```

Updating to fastify@v2 removes the deprecation warning
```console
$ npm install
audited 91 packages in 0.559s

1 package is looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

### Testing
Verified that analysis in [Reducing the graph size](https://clinicjs.org/documentation/flame/07-reducing-the-graph-size/) still holds good with fastify@v2